### PR TITLE
Changes for docmanager2

### DIFF
--- a/config.sample.properties
+++ b/config.sample.properties
@@ -1,0 +1,43 @@
+# The port the server will listen to accept requests
+server-port=8732
+
+# Cache folder for transient files
+# default = the OS' temp folder
+# WARNING: Remember to escape backslashes (\\) in Windows paths
+cache-folder=
+
+# Backup folder for failed conversions
+# All the temp files of failed conversion will be moved here
+# default = empty, so on error the temp files are not saved
+# WARNING: Remember to escape backslashes (\\) in Windows paths
+errors-folder=
+
+# Delete cached projects when closed
+# default = true
+delete-on-close=true
+
+# MateCat Win Converter: configure it to support more formats.
+# More info: https://github.com/matecat/MateCat-Win-Converter
+# First enable your Win Converter with this param
+win-conv-enabled=false
+# Put here the address of your Win Converter
+win-conv-host=localhost
+win-conv-port=11000
+# More instances can also be registered in a Consul service.
+# Filters will try to connect to the nearest healthy instance
+# first, and fallback on the others in case of error.
+# With Consul available, host/port params above are ignored.
+win-conv-consul-address=localhost:8500
+win-conv-consul-service=matecat-win-converter
+
+# Custom segmentation folder
+# when converting to XLIFF it is possible to specify a custom .srx file to be used for segmentation phase.
+# If above parameter is provided, the application will look for it into this folder
+custom-segmentation-folder=/media/llcampos/DATA/Dropbox/Unbabel/unbabel-document-manager/docmanager
+
+# Custom filters
+# Write the full class name, including package, of the
+# classes to load as custom filters. These classes must
+# implement the ICustomFilter interface. Separate
+# different classes with comma ",".
+#custom-filters=com.yourcompany.KittyFilter

--- a/config.sample.properties
+++ b/config.sample.properties
@@ -33,7 +33,7 @@ win-conv-consul-service=matecat-win-converter
 # Custom segmentation folder
 # when converting to XLIFF it is possible to specify a custom .srx file to be used for segmentation phase.
 # If above parameter is provided, the application will look for it into this folder
-custom-segmentation-folder=/media/llcampos/DATA/Dropbox/Unbabel/unbabel-document-manager/docmanager
+custom-segmentation-folder=../src/main/resources/okapi/segmentation/
 
 # Custom filters
 # Write the full class name, including package, of the

--- a/filters/src/main/java/com/matecat/converter/core/okapiclient/OkapiClient.java
+++ b/filters/src/main/java/com/matecat/converter/core/okapiclient/OkapiClient.java
@@ -117,13 +117,13 @@ public class OkapiClient {
      * @param sourceLanguage Source language
      * @param segmentation the name of the custom segmentation file to use (if any), or <code>null</code> to fallback on default
      * @param driver a reference to the current driver to be populated with the segmentation step
-     * 
+     *
      * @see Config.customSegmentationFolder
      */
     private static void createSegmentationStep(Locale sourceLanguage, String segmentation, IPipelineDriver driver) {
         SegmentationStep segmentationStep = new SegmentationStep();
         net.sf.okapi.steps.segmentation.Parameters params = (net.sf.okapi.steps.segmentation.Parameters) segmentationStep.getParameters();
-        
+
         String customSegmentationFilePath = getCustomSegmentationFilePath(segmentation);
 
         if( customSegmentationFilePath != null ) {
@@ -136,13 +136,13 @@ public class OkapiClient {
 	        driver.addStep(new RemoveIcuHintsStep());
         }
     }
-    
-    
+
+
     /**
-     * given a segmentation name, check if exists a corresponding file with custom segmentation rules and return its path 
+     * given a segmentation name, check if exists a corresponding file with custom segmentation rules and return its path
      * @param segmentation
      * @return the full path of the file containing the specified segmentation rules, or null if no custom segmentation has been defined
-     * @throws RuntimeException if the file does not exist or there are no read permissions on it 
+     * @throws RuntimeException if the file does not exist or there are no read permissions on it
      */
     private static String getCustomSegmentationFilePath(String segmentation) {
     	// no custom segmentation required
@@ -150,54 +150,54 @@ public class OkapiClient {
         	LOGGER.info("Using default segmentation");
         	return null;
         }
-        
+
 		// the custom segmentation folder is empty, skip all checks and use default rules
 		if( Config.customSegmentationFolder.isEmpty() ) {
 			LOGGER.info("No custom segmentation folder, falling back to default segmentation");
 			throw new IllegalStateException("Custom segmentation file requested, but no segmentation folder configured. File: " + Config.customSegmentationFolder + segmentation + ".srx");
 		}
-		
-		
+
+
 		/* A custom segmentation has been requested, and there is a valid custom segmentation rules folder.
 		 * Try to get the proper file, if it is not found or not accessible, raise an exception for the client.
 		 * That is why no exception handling has been defined here
 		 */
-				
+
 		// instantiate a file wrapper to make all the necessary checks
 		File segmentationFile = new File(Config.customSegmentationFolder + segmentation + ".srx");
-		
+
 		/* Check if the corresponding file exists
-		 *  
+		 *
 		 * IMPORTANT
 		 * Read permission in folder Config.customSegmentationFolder are check only once at startup time from Config class.
 		 * If these permissions change at runtime and the application becomes not allowed to read from it, the following check will fail
 		 * because it will try to read the folder content, and an empty set of files will be returned, due to the permission issue.
-		 * 
+		 *
 		 *  Sample Scenario:
 		 *   - application loads and at startup time is able to read from Config.customSegmentationFolder
 		 *   - permission on the folder change, and the application cannot read from it anymore
 		 *   - user issues a conversion request and the application tries to look for the specified segmentation file from custom folder
 		 *   - because of read limitation, OS will return the application an empty set of files
 		 *   - the application will correctly fallback on default srx file, but with following "not found" error message
-		 *  
-		 * Even though the behaviuor is correct (and this case should not happen), the error message might be trivial 
-		 */ 
+		 *
+		 * Even though the behaviuor is correct (and this case should not happen), the error message might be trivial
+		 */
 		if(!segmentationFile.isFile()) {
 			LOGGER.warn("Custom segmentation file not found. File: " + Config.customSegmentationFolder + segmentation + ".srx");
 			throw new IllegalArgumentException("Custom segmentation file not found. File: " + Config.customSegmentationFolder + segmentation + ".srx");
 		}
-	
+
 		// Check if the corresponding file can be read
 		if(!segmentationFile.canRead()) {
 			LOGGER.warn("Custom segmentation file cannot be read. File: " + Config.customSegmentationFolder + segmentation + ".srx");
 			throw new IllegalArgumentException("Custom segmentation file cannot be read. File: " + Config.customSegmentationFolder + segmentation + ".srx");
 		}
-	
+
 		// the file exists and can be read, return its path
 		LOGGER.info("Using custom segmentation in file: " + segmentationFile.getPath());
-		return segmentationFile.getPath();	
+		return segmentationFile.getPath();
     }
-    
+
 
     /**
      * Create the extraction step
@@ -207,6 +207,9 @@ public class OkapiClient {
         ExtractionStep extStep = new ExtractionStep();
         net.sf.okapi.steps.rainbowkit.creation.Parameters extParams = (net.sf.okapi.steps.rainbowkit.creation.Parameters) extStep.getParameters();
         extParams.setPackageName(OkapiPack.PACK_FILENAME);
+        // Output extended code attributes
+        extParams.setWriterOptions("#v1\nincludeCodeAttrs.b=true");
+
         return extStep;
     }
 

--- a/filters/src/main/resources/okapi/configurations/okf_html-custom.fprm
+++ b/filters/src/main/resources/okapi/configurations/okf_html-custom.fprm
@@ -4,9 +4,6 @@ attributes:
   dir:
     ruleTypes: [ATTRIBUTE_WRITABLE]
     allElementsExcept: [base, basefront, head, html, meta, param, script]
-  title:
-    ruleTypes: [ATTRIBUTE_TRANS]
-    allElementsExcept: [base, basefront, head, html, meta, param, script, title]
   lang:
     ruleTypes: [ATTRIBUTE_WRITABLE]
   xml:lang:
@@ -101,7 +98,7 @@ elements:
   a:
     ruleTypes: [INLINE]
     elementType: link
-    translatableAttributes: [title, accesskey]
+    translatableAttributes: [accesskey]
     writableLocalizableAttributes: [href]
   abbr:
     ruleTypes: [INLINE]

--- a/filters/src/main/resources/okapi/segmentation/no-segmentation.srx
+++ b/filters/src/main/resources/okapi/segmentation/no-segmentation.srx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<srx xmlns="http://www.lisa.org/srx20" version="2.0">
+ <header>
+ </header>
+ <body>
+  <languagerules>
+  </languagerules>
+  <maprules>
+  </maprules>
+ </body>
+</srx>


### PR DESCRIPTION
Adapted Matecat Filters for our needs in Unbabel's Document Manager 2.0.
- Add the option of segmentation "no-segmentation", in which the XLIFF coming from Matecat Filters does not have the <seg-source> or the <target> elements segmented (technically, it is segmented because it is surrounded by <mrk> tags, but it's just one segment).

So instead of this:

``` xml
<target xml:lang="und">
<mrk mid="0" mtype="seg">Right now, Amazon.ca is selling the Beyerdynamic MMX 102 iE In-Ear Headset, Black/Silver for $59.99 (Reg. </mrk>
<mrk mid="1" mtype="seg">$152.89) with free shipping in 1-2 months. </mrk>
<mrk mid="2" mtype="seg">That's a great price if you don't mind waiting! </mrk>
</target>
```

We have this:

``` xml
<target xml:lang="und">
<mrk mid="0" mtype="seg">Right now, Amazon.ca is selling the Beyerdynamic MMX 102 iE In-Ear Headset, Black/Silver for $59.99 (Reg. $152.89) with free shipping in 1-2 months. That's a great price if you don't mind waiting! </mrk>
</target>
```
- Filters extracts the values of some attributes of tags, like the value of the "title" attribute in a HTML `<a>` tag, for example. By editing the "okf_html-custom.fprm" we can change what is extacted for the HTML. For now, I deactivated the extraction of "title" attributes, at least in the `<a>` tag. 
- Activate the option of output extended code attributes, so that ctype and equiv-text attributes are included in inline codes. Like so:

``` xml
<source xml:lang="und">Right now, Amazon.ca is selling the <g ctype="link" equiv-text="[#$sd1_dp1]" id="1">Beyerdynamic MMX 102 iE In-Ear Headset, Black/Silver for $59.99</g> (Reg. $152.89) with free shipping in 1-2 months. That's a great price if you don't mind waiting!</source>
```
